### PR TITLE
Fix Broken Parameter Name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   name: python-dev
-  version: 'v1.0.2'
+  version: 'v1.0.3'
   author: Naftuli Kay
   description: Install and configure a Python development environment on a system.
 

--- a/tasks/pyenv.yml
+++ b/tasks/pyenv.yml
@@ -14,7 +14,7 @@
 
 - name: patch bashrc
   blockinfile:
-    path: "{{ python_user_home }}/.bashrc"
+    dest: "{{ python_user_home }}/.bashrc"
     owner: "{{ python_user }}"
     group: "{{ python_user }}"
     marker: "# {mark} ansible: naftulikay.python-dev"


### PR DESCRIPTION
Before 2.3, this didn't work. Curse you Ansible for not making these things outstandingly clear in the docs :fist_oncoming: 